### PR TITLE
GC, parent call and js.get

### DIFF
--- a/lua.js
+++ b/lua.js
@@ -48,8 +48,10 @@ var Lua = {
     }
   },
   funcWrapper: function(i) {
+    var realthis = this;
     return function() {
-      Lua.execute('js.lua_table[' + i + ']()'); 
+      if (realthis.reverseWrappers[this]) Lua.execute('js.lua_table[' + i + '](js.storeGet('+realthis.reverseWrappers[this]+'))');
+      else Lua.execute('js.lua_table[' + i + ']()');
     };
   }
 };


### PR DESCRIPTION
js.get always return the same table if the same js object/function is referenced
garbage collection work, so when a js.get'ed variable is collected in lua, the corresponding thing in the Lua.wrappers table will be freed too
parent object is tracked to make calls with a correct "this"
foo.bar = zog works, correctly assigning it on the JS side
when a lua callback is called, if "this" is in the lua store it gets passed as the first parameter (aka "self")
